### PR TITLE
Fix: Update Page components to handle async params for Next.js 15.x

### DIFF
--- a/src/app/(home)/[[...slug]]/page.tsx
+++ b/src/app/(home)/[[...slug]]/page.tsx
@@ -3,11 +3,12 @@ import HomePage from "../../components/pages/home-page";
 import pathParser from "../../utils/path-parser";
 import NotFoundPage from "../../components/pages/not-found-page";
 
-export default function Page({
-  params = { slug: [] },
+export default async function Page({
+  params: paramsPromise = Promise.resolve({ slug: [] }),
 }: {
-  params: { slug: string[] };
+  params: Promise<{ slug: string[] }>;
 }) {
+  const params = await paramsPromise;
   const { theme, remainingSlug, deploymentConfiguration } = pathParser(
     params.slug,
   );

--- a/src/app/deploy/[[...slug]]/page.tsx
+++ b/src/app/deploy/[[...slug]]/page.tsx
@@ -2,11 +2,12 @@ import DeployPage from "../../components/pages/deploy-page";
 import NotFoundPage from "../../components/pages/not-found-page";
 import pathParser from "../../utils/path-parser";
 
-export default function Page({
-  params = { slug: [] },
+export default async function Page({
+  params: paramsPromise = Promise.resolve({ slug: [] }),
 }: {
-  params: { slug: string[] };
+  params: Promise<{ slug: string[] }>;
 }) {
+  const params = await paramsPromise;
   const { theme, remainingSlug, deploymentConfiguration } = pathParser(
     params.slug,
   );

--- a/src/app/faq/[[...slug]]/page.tsx
+++ b/src/app/faq/[[...slug]]/page.tsx
@@ -2,11 +2,12 @@ import FaqPage from "../../components/pages/faq-page";
 import NotFoundPage from "../../components/pages/not-found-page";
 import pathParser from "../../utils/path-parser";
 
-export default function Page({
-  params = { slug: [] },
+export default async function Page({
+  params: paramsPromise = Promise.resolve({ slug: [] }),
 }: {
-  params: { slug: string[] };
+  params: Promise<{ slug: string[] }>;
 }) {
+  const params = await paramsPromise;
   const { theme, remainingSlug, deploymentConfiguration } = pathParser(
     params.slug,
   );


### PR DESCRIPTION
I resolved a build failure caused by Next.js 15.x expecting `params` props in Page components to be Promises.

I modified the following files:
- src/app/(home)/[[...slug]]/page.tsx
- src/app/deploy/[[...slug]]/page.tsx
- src/app/faq/[[...slug]]/page.tsx

Changes include making the Page components async, updating type annotations for `params` to be Promises, and awaiting the `params` object before use.