### PR TITLE
Modernize with Next.js 16 (PPR, use cache)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
+  cacheComponents: true,
+  experimental: {
+    useCache: true,
+  },
 };
 
 module.exports = nextConfig;

--- a/src/app/(home)/[[...slug]]/page.tsx
+++ b/src/app/(home)/[[...slug]]/page.tsx
@@ -1,55 +1,26 @@
-import { Theme } from "../../types";
-import HomePage from "../../components/pages/home-page";
-import pathParser from "../../utils/path-parser";
-import NotFoundPage from "../../components/pages/not-found-page";
-import { Metadata } from "next";
+import SharedPage from "../../components/shared-page";
+import {
+  generateMetadataForSlug,
+  getStaticParamsForRoute,
+} from "../../utils/metadata-helper";
 
 export async function generateMetadata({
-  params: paramsPromise = Promise.resolve({ slug: [] }),
-}: {
-  params: Promise<{ slug: string[] }>;
-}): Promise<Metadata> {
-  const params = await paramsPromise;
-  const { theme } = pathParser(params.slug);
-
-  let icon = "/favicons/smiling-face.svg";
-  if (theme.vibe === "professional") {
-    icon = "/favicons/briefcase.svg";
-  } else if (theme.vibe === "fun") {
-    icon = "/favicons/party-popper.svg";
-  }
-
-  return {
-    icons: {
-      icon: icon,
-    },
-  };
-}
-
-export default async function Page({
-  params: paramsPromise = Promise.resolve({ slug: [] }),
+  params,
 }: {
   params: Promise<{ slug: string[] }>;
 }) {
-  const params = await paramsPromise;
-  const { theme, remainingSlug, deploymentConfiguration } = pathParser(
-    params.slug,
-  );
+  const { slug } = await params;
+  return generateMetadataForSlug(slug);
+}
 
-  if (remainingSlug.length > 0) {
-    return (
-      <NotFoundPage
-        theme={{ ...theme, page: "not-found" }}
-        remainingSlug={remainingSlug}
-        deploymentConfiguration={deploymentConfiguration}
-        slug={params.slug}
-      />
-    );
-  }
-  return (
-    <HomePage
-      theme={{ ...theme, page: "home" }}
-      deploymentConfiguration={deploymentConfiguration}
-    />
-  );
+export async function generateStaticParams() {
+  return getStaticParamsForRoute();
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>;
+}) {
+  return <SharedPage page="home" params={params} />;
 }

--- a/src/app/components/shared-page.tsx
+++ b/src/app/components/shared-page.tsx
@@ -1,0 +1,59 @@
+import { Suspense } from "react";
+import { cachedPathParser } from "../utils/path-parser";
+import { PageOption } from "../types";
+import HomePage from "./pages/home-page";
+import DeployPage from "./pages/deploy-page";
+import FaqPage from "./pages/faq-page";
+import NotFoundPage from "./pages/not-found-page";
+
+type SharedPageProps = {
+  page: PageOption;
+  params: Promise<{ slug: string[] }>;
+};
+
+async function PageContent({ page, params }: SharedPageProps) {
+  const { slug } = await params;
+  const { theme, remainingSlug, deploymentConfiguration } =
+    await cachedPathParser(slug);
+
+  if (remainingSlug.length > 0) {
+    return (
+      <NotFoundPage
+        theme={{ ...theme, page: "not-found" }}
+        remainingSlug={remainingSlug}
+        deploymentConfiguration={deploymentConfiguration}
+        slug={slug}
+      />
+    );
+  }
+
+  const commonProps = {
+    theme: { ...theme, page },
+    deploymentConfiguration,
+  };
+
+  switch (page) {
+    case "home":
+      return <HomePage {...commonProps} />;
+    case "deploy":
+      return <DeployPage {...commonProps} />;
+    case "faq":
+      return <FaqPage {...commonProps} />;
+    default:
+      return (
+        <NotFoundPage
+          {...commonProps}
+          remainingSlug={remainingSlug}
+          slug={slug}
+        />
+      );
+  }
+}
+
+export default function SharedPage(props: SharedPageProps) {
+  return (
+    <Suspense fallback={<div className="min-h-screen w-full" />}>
+      <PageContent {...props} />
+    </Suspense>
+  );
+}

--- a/src/app/deploy/[[...slug]]/page.tsx
+++ b/src/app/deploy/[[...slug]]/page.tsx
@@ -1,54 +1,26 @@
-import DeployPage from "../../components/pages/deploy-page";
-import NotFoundPage from "../../components/pages/not-found-page";
-import pathParser from "../../utils/path-parser";
-import { Metadata } from "next";
+import SharedPage from "../../components/shared-page";
+import {
+  generateMetadataForSlug,
+  getStaticParamsForRoute,
+} from "../../utils/metadata-helper";
 
 export async function generateMetadata({
-  params: paramsPromise = Promise.resolve({ slug: [] }),
-}: {
-  params: Promise<{ slug: string[] }>;
-}): Promise<Metadata> {
-  const params = await paramsPromise;
-  const { theme } = pathParser(params.slug);
-
-  let icon = "/favicons/smiling-face.svg";
-  if (theme.vibe === "professional") {
-    icon = "/favicons/briefcase.svg";
-  } else if (theme.vibe === "fun") {
-    icon = "/favicons/party-popper.svg";
-  }
-
-  return {
-    icons: {
-      icon: icon,
-    },
-  };
-}
-
-export default async function Page({
-  params: paramsPromise = Promise.resolve({ slug: [] }),
+  params,
 }: {
   params: Promise<{ slug: string[] }>;
 }) {
-  const params = await paramsPromise;
-  const { theme, remainingSlug, deploymentConfiguration } = pathParser(
-    params.slug,
-  );
+  const { slug } = await params;
+  return generateMetadataForSlug(slug);
+}
 
-  if (remainingSlug.length > 0) {
-    return (
-      <NotFoundPage
-        theme={{ ...theme, page: "not-found" }}
-        deploymentConfiguration={deploymentConfiguration}
-        remainingSlug={remainingSlug}
-        slug={params.slug}
-      />
-    );
-  }
-  return (
-    <DeployPage
-      theme={{ ...theme, page: "deploy" }}
-      deploymentConfiguration={deploymentConfiguration}
-    />
-  );
+export async function generateStaticParams() {
+  return getStaticParamsForRoute();
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>;
+}) {
+  return <SharedPage page="deploy" params={params} />;
 }

--- a/src/app/faq/[[...slug]]/page.tsx
+++ b/src/app/faq/[[...slug]]/page.tsx
@@ -1,54 +1,26 @@
-import FaqPage from "../../components/pages/faq-page";
-import NotFoundPage from "../../components/pages/not-found-page";
-import pathParser from "../../utils/path-parser";
-import { Metadata } from "next";
+import SharedPage from "../../components/shared-page";
+import {
+  generateMetadataForSlug,
+  getStaticParamsForRoute,
+} from "../../utils/metadata-helper";
 
 export async function generateMetadata({
-  params: paramsPromise = Promise.resolve({ slug: [] }),
-}: {
-  params: Promise<{ slug: string[] }>;
-}): Promise<Metadata> {
-  const params = await paramsPromise;
-  const { theme } = pathParser(params.slug);
-
-  let icon = "/favicons/smiling-face.svg";
-  if (theme.vibe === "professional") {
-    icon = "/favicons/briefcase.svg";
-  } else if (theme.vibe === "fun") {
-    icon = "/favicons/party-popper.svg";
-  }
-
-  return {
-    icons: {
-      icon: icon,
-    },
-  };
-}
-
-export default async function Page({
-  params: paramsPromise = Promise.resolve({ slug: [] }),
+  params,
 }: {
   params: Promise<{ slug: string[] }>;
 }) {
-  const params = await paramsPromise;
-  const { theme, remainingSlug, deploymentConfiguration } = pathParser(
-    params.slug,
-  );
+  const { slug } = await params;
+  return generateMetadataForSlug(slug);
+}
 
-  if (remainingSlug.length > 0) {
-    return (
-      <NotFoundPage
-        theme={{ ...theme, page: "not-found" }}
-        remainingSlug={remainingSlug}
-        deploymentConfiguration={deploymentConfiguration}
-        slug={params.slug}
-      />
-    );
-  }
-  return (
-    <FaqPage
-      theme={{ ...theme, page: "faq" }}
-      deploymentConfiguration={deploymentConfiguration}
-    />
-  );
+export async function generateStaticParams() {
+  return getStaticParamsForRoute();
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string[] }>;
+}) {
+  return <SharedPage page="faq" params={params} />;
 }

--- a/src/app/utils/metadata-helper.ts
+++ b/src/app/utils/metadata-helper.ts
@@ -1,0 +1,29 @@
+import { Metadata } from "next";
+import { cachedPathParser } from "./path-parser";
+import { VIBE_OPTIONS } from "../types";
+
+export async function generateMetadataForSlug(
+  slug?: string[],
+): Promise<Metadata> {
+  const { theme } = await cachedPathParser(slug);
+
+  let icon = "/favicons/smiling-face.svg";
+  if (theme.vibe === "professional") {
+    icon = "/favicons/briefcase.svg";
+  } else if (theme.vibe === "fun") {
+    icon = "/favicons/party-popper.svg";
+  }
+
+  return {
+    icons: {
+      icon: icon,
+    },
+  };
+}
+
+export async function getStaticParamsForRoute() {
+  return [
+    { slug: [] },
+    ...VIBE_OPTIONS.map((vibe) => ({ slug: [vibe] })),
+  ];
+}

--- a/src/app/utils/path-parser.ts
+++ b/src/app/utils/path-parser.ts
@@ -19,7 +19,7 @@ import {
   VibeOption,
 } from "../types";
 
-export default function pathParser(slug?: string[]) {
+export function pathParser(slug?: string[]) {
   let theme: Theme = {
     page: "not-found",
     vibe: "standard",
@@ -43,38 +43,43 @@ export default function pathParser(slug?: string[]) {
     theme.page = "home";
     remainingSlug.shift();
   }
-  if (PAGE_OPTIONS.includes(remainingSlug[0])) {
+  if (PAGE_OPTIONS.includes(remainingSlug[0] as PageOption)) {
     theme.page = remainingSlug[0] as PageOption;
     remainingSlug.shift();
   }
-  if (VIBE_OPTIONS.includes(remainingSlug[0])) {
+  if (VIBE_OPTIONS.includes(remainingSlug[0] as VibeOption)) {
     theme.vibe = remainingSlug[0] as VibeOption;
     remainingSlug.shift();
   }
-  if (COLOR_OPTIONS.includes(remainingSlug[0])) {
+  if (COLOR_OPTIONS.includes(remainingSlug[0] as ColorOption)) {
     theme.color = remainingSlug[0] as ColorOption;
     remainingSlug.shift();
   }
-  if (TENSE_OPTIONS.includes(remainingSlug[0])) {
+  if (TENSE_OPTIONS.includes(remainingSlug[0] as TenseOption)) {
     theme.tense = remainingSlug[0] as TenseOption;
     remainingSlug.shift();
   }
-  if (VERBOSITY_OPTIONS.includes(remainingSlug[0])) {
+  if (VERBOSITY_OPTIONS.includes(remainingSlug[0] as VerbosityOption)) {
     theme.verbosity = remainingSlug[0] as VerbosityOption;
     remainingSlug.shift();
   }
-  if (FRAMEWORK_OPTIONS.includes(remainingSlug[0])) {
+  if (FRAMEWORK_OPTIONS.includes(remainingSlug[0] as FrameworkOption)) {
     deploymentConfiguration.framework = remainingSlug[0] as FrameworkOption;
     remainingSlug.shift();
   }
-  if (TARGET_OPTIONS.includes(remainingSlug[0])) {
+  if (TARGET_OPTIONS.includes(remainingSlug[0] as TargetOption)) {
     deploymentConfiguration.target = remainingSlug[0] as TargetOption;
     remainingSlug.shift();
   }
-  if (SOURCE_OPTIONS.includes(remainingSlug[0])) {
+  if (SOURCE_OPTIONS.includes(remainingSlug[0] as SourceOption)) {
     deploymentConfiguration.source = remainingSlug[0] as SourceOption;
     remainingSlug.shift();
   }
 
   return { theme, deploymentConfiguration, remainingSlug };
+}
+
+export async function cachedPathParser(slug?: string[]) {
+  "use cache";
+  return pathParser(slug);
 }


### PR DESCRIPTION
This submission modernizes the repository by implementing the latest guidance from Vercel for Next.js 15/16. 

Key changes include:
1. **Performance Optimizations**: 
   - Enabled Partial Prerendering (PPR) to allow static shells with dynamic streaming.
   - Introduced the `"use cache"` directive for the path parsing logic to optimize server-side computations.
   - Added `generateStaticParams` to pre-render common URL combinations.
2. **Architectural Improvements**:
   - Created a `SharedPage` component to DRY up the logic between the home, deploy, and FAQ pages.
   - Centralized metadata logic in `metadata-helper.ts`.
3. **Compatibility**:
   - Updated all page components and `generateMetadata` functions to correctly handle asynchronous `params`, as required by the latest Next.js versions.

Verified the changes with a full production build (`pnpm build`) and confirmed that the routes are being partially pre-rendered as expected.

---
*PR created automatically by Jules for task [11792083836279219376](https://jules.google.com/task/11792083836279219376) started by @LukeSchlangen*