### PR TITLE
Statically generate all pages

### DIFF
--- a/src/app/(home)/[[...slug]]/page.tsx
+++ b/src/app/(home)/[[...slug]]/page.tsx
@@ -3,6 +3,12 @@ import HomePage from "../../components/pages/home-page";
 import pathParser from "../../utils/path-parser";
 import NotFoundPage from "../../components/pages/not-found-page";
 import { Metadata } from "next";
+import { getSlugsForPage } from "../../utils/static-params";
+
+export async function generateStaticParams() {
+  const slugs = getSlugsForPage();
+  return slugs.map((slug) => ({ slug }));
+}
 
 export async function generateMetadata({
   params: paramsPromise = Promise.resolve({ slug: [] }),

--- a/src/app/deploy/[[...slug]]/page.tsx
+++ b/src/app/deploy/[[...slug]]/page.tsx
@@ -2,6 +2,12 @@ import DeployPage from "../../components/pages/deploy-page";
 import NotFoundPage from "../../components/pages/not-found-page";
 import pathParser from "../../utils/path-parser";
 import { Metadata } from "next";
+import { getSlugsForPage } from "../../utils/static-params";
+
+export async function generateStaticParams() {
+  const slugs = getSlugsForPage("deploy");
+  return slugs.map((slug) => ({ slug }));
+}
 
 export async function generateMetadata({
   params: paramsPromise = Promise.resolve({ slug: [] }),

--- a/src/app/faq/[[...slug]]/page.tsx
+++ b/src/app/faq/[[...slug]]/page.tsx
@@ -2,6 +2,12 @@ import FaqPage from "../../components/pages/faq-page";
 import NotFoundPage from "../../components/pages/not-found-page";
 import pathParser from "../../utils/path-parser";
 import { Metadata } from "next";
+import { getSlugsForPage } from "../../utils/static-params";
+
+export async function generateStaticParams() {
+  const slugs = getSlugsForPage("faq");
+  return slugs.map((slug) => ({ slug }));
+}
 
 export async function generateMetadata({
   params: paramsPromise = Promise.resolve({ slug: [] }),

--- a/src/app/utils/static-params.ts
+++ b/src/app/utils/static-params.ts
@@ -1,0 +1,60 @@
+import {
+  COLOR_OPTIONS,
+  FRAMEWORK_OPTIONS,
+  PAGE_OPTIONS,
+  SOURCE_OPTIONS,
+  TARGET_OPTIONS,
+  TENSE_OPTIONS,
+  VERBOSITY_OPTIONS,
+  VIBE_OPTIONS,
+} from "../types";
+
+export function getAllPossibleSlugs(): string[][] {
+  const categories = [
+    PAGE_OPTIONS,
+    VIBE_OPTIONS,
+    COLOR_OPTIONS,
+    TENSE_OPTIONS,
+    VERBOSITY_OPTIONS,
+    FRAMEWORK_OPTIONS,
+    TARGET_OPTIONS,
+    SOURCE_OPTIONS,
+  ];
+
+  let slugs: string[][] = [[]];
+
+  for (const options of categories) {
+    const nextSlugs: string[][] = [];
+    for (const slug of slugs) {
+      // Option 1: Skip this category
+      nextSlugs.push(slug);
+      // Option 2: Include one of the options
+      for (const option of options) {
+        nextSlugs.push([...slug, option]);
+      }
+    }
+    slugs = nextSlugs;
+  }
+
+  return slugs;
+}
+
+export function getSlugsForPage(baseRoute?: "faq" | "deploy") {
+  const allSlugs = getAllPossibleSlugs();
+
+  if (baseRoute) {
+    // For specialized routes (/faq, /deploy), we only want slugs
+    // that don't have an explicit page segment at the start to avoid
+    // redundant paths like /faq/faq or /faq/home.
+    return allSlugs.filter(
+      (slug) => slug.length === 0 || !PAGE_OPTIONS.includes(slug[0] as any),
+    );
+  }
+
+  // For the root/home catch-all, we include slugs that don't start
+  // with specialized routes (faq, deploy) to avoid routing conflicts.
+  return allSlugs.filter(
+    (slug) =>
+      slug.length === 0 || (slug[0] !== "faq" && slug[0] !== "deploy"),
+  );
+}


### PR DESCRIPTION
This change adds static generation for all possible pages on the website. It uses a combinatorial approach to generate all valid slugs based on the options defined in the types. It also includes filtering logic to ensure that slugs are correctly routed and avoid redundant paths, while still providing exhaustive coverage as requested.

---
*PR created automatically by Jules for task [15131992504091625596](https://jules.google.com/task/15131992504091625596) started by @LukeSchlangen*