### PR TITLE
Eliminate horizontal overflow on all pages

### DIFF
--- a/src/app/components/pages/deploy-page.tsx
+++ b/src/app/components/pages/deploy-page.tsx
@@ -74,7 +74,7 @@ export default function DeployPage({
   ];
 
   return (
-    <div className={`min-w-screen min-h-screen ${textColorClass}`}>
+    <div className={`w-full min-h-screen ${textColorClass}`}>
       <style>
         {/* Hacky style tag applied to body here because body has to be defined in layout, but style depends on theme */}
         {`body { background-color: ${bodyBackgroundColor} }`}

--- a/src/app/components/pages/faq-page.tsx
+++ b/src/app/components/pages/faq-page.tsx
@@ -17,7 +17,7 @@ export default function FaqPage({
   const { textColorClass, bodyBackgroundColor } = colorValues(theme);
 
   return (
-    <div className={`min-w-screen min-h-screen ${textColorClass}`}>
+    <div className={`w-full min-h-screen ${textColorClass}`}>
       <style>
         {/* Hacky style tag applied to body here because body has to be defined in layout, but style depends on theme */}
         {`body { background-color: ${bodyBackgroundColor} }`}

--- a/src/app/components/pages/home-page.tsx
+++ b/src/app/components/pages/home-page.tsx
@@ -20,7 +20,7 @@ export default function HomePage({
     colorValues(theme);
 
   return (
-    <div className={`min-w-screen min-h-screen ${textColorClass}`}>
+    <div className={`w-full min-h-screen ${textColorClass}`}>
       <style>
         {/* Hacky style tag applied to body here because body has to be defined in layout, but style depends on theme */}
         {`body { background-color: ${bodyBackgroundColor} }`}

--- a/src/app/components/pages/not-found-page.tsx
+++ b/src/app/components/pages/not-found-page.tsx
@@ -19,7 +19,7 @@ export default function NotFoundPage({
   const { textColorClass, bodyBackgroundColor } = colorValues(theme);
 
   return (
-    <div className={`min-w-screen min-h-screen ${textColorClass}`}>
+    <div className={`w-full min-h-screen ${textColorClass}`}>
       <style>
         {/* Hacky style tag applied to body here because body has to be defined in layout, but style depends on theme */}
         {`body { background-color: ${bodyBackgroundColor} }`}


### PR DESCRIPTION
Replaced `min-w-screen` with `w-full` in all major page components to fix horizontal scrolling issues caused by viewport width units. verified the fix using Playwright screenshots.

---
*PR created automatically by Jules for task [6810547395963564575](https://jules.google.com/task/6810547395963564575) started by @LukeSchlangen*