### PR TITLE
Fix Lighthouse Score: SEO and Metadata Improvements

### DIFF
--- a/src/app/(home)/[[...slug]]/page.tsx
+++ b/src/app/(home)/[[...slug]]/page.tsx
@@ -20,6 +20,9 @@ export async function generateMetadata({
   }
 
   return {
+    title: "Luke Schlangen | Software Engineer",
+    description:
+      "Luke Schlangen's personal website. Software engineer, educator, and lifelong learner.",
     icons: {
       icon: icon,
     },

--- a/src/app/deploy/[[...slug]]/page.tsx
+++ b/src/app/deploy/[[...slug]]/page.tsx
@@ -19,6 +19,8 @@ export async function generateMetadata({
   }
 
   return {
+    title: "Deploy | Luke Schlangen",
+    description: "Deployment steps for various frameworks and targets.",
     icons: {
       icon: icon,
     },

--- a/src/app/faq/[[...slug]]/page.tsx
+++ b/src/app/faq/[[...slug]]/page.tsx
@@ -19,6 +19,8 @@ export async function generateMetadata({
   }
 
   return {
+    title: "FAQ | Luke Schlangen",
+    description: "Frequently asked questions about Luke Schlangen.",
     icons: {
       icon: icon,
     },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
 import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Luke Schlangen | Software Engineer",
+  description:
+    "Luke Schlangen's personal website. Software engineer, educator, and lifelong learner.",
+};
 
 export default function RootLayout({
   children,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://www.luke.mn/sitemap.xml",
+  };
+}


### PR DESCRIPTION
I have improved the Lighthouse score by addressing missing SEO and accessibility metadata. 

Key changes:
- Created `src/app/robots.ts` to ensure `robots.txt` is served correctly as plain text rather than being intercepted by the catch-all HTML routes.
- Updated `generateMetadata` in `src/app/(home)/[[...slug]]/page.tsx`, `src/app/deploy/[[...slug]]/page.tsx`, and `src/app/faq/[[...slug]]/page.tsx` to provide descriptive titles and meta descriptions.
- Added default `metadata` to `src/app/layout.tsx` to serve as a fallback for all pages.

These changes directly resolve the failing Lighthouse audits for missing document titles and meta descriptions, and fix the malformed robots.txt issue.

---
*PR created automatically by Jules for task [3504339550422575831](https://jules.google.com/task/3504339550422575831) started by @LukeSchlangen*