### PR TITLE
Fix Lighthouse LCP and Unused JS issues

### DIFF
--- a/src/app/components/pages/deploy-page.tsx
+++ b/src/app/components/pages/deploy-page.tsx
@@ -110,6 +110,7 @@ export default function DeployPage({
                               ...deploymentConfiguration,
                               framework,
                             })}
+                            prefetch={false}
                             className={
                               deploymentConfiguration.framework === framework
                                 ? "underline"
@@ -141,6 +142,7 @@ export default function DeployPage({
                               ...deploymentConfiguration,
                               target,
                             })}
+                            prefetch={false}
                             className={
                               deploymentConfiguration.target === target
                                 ? "underline"

--- a/src/app/components/profile-image.tsx
+++ b/src/app/components/profile-image.tsx
@@ -15,27 +15,27 @@ export default function ProfileImage({ theme }: { theme: Theme }) {
     <div className="relative flex justify-center h-[400px] w-full overflow-hidden">
       
       <Image 
-        className={`${imgBaseClass} ${theme.vibe !== 'professional' ? 'translate-y-100' : 'translate-y-0'}`} 
+        className={`${imgBaseClass} ${theme.vibe !== 'professional' ? 'translate-y-[400px]' : 'translate-y-0'}`}
         src={blackSuit} 
         alt="Luke Schlangen in a Black Suit" 
         height={400} 
-        priority 
+        priority={theme.vibe === 'professional'}
       />
       
       <Image 
-        className={`${imgBaseClass} ${theme.vibe !== 'standard' ? 'translate-y-100' : 'translate-y-0'}`} 
+        className={`${imgBaseClass} ${theme.vibe !== 'standard' ? 'translate-y-[400px]' : 'translate-y-0'}`}
         src={greySweater} 
         alt="Luke Schlangen in a Grey Sweater" 
         height={400} 
-        priority 
+        priority={theme.vibe === 'standard'}
       />
       
       <Image 
-        className={`${imgBaseClass} ${theme.vibe !== 'fun' ? 'translate-y-100' : 'translate-y-0'}`} 
+        className={`${imgBaseClass} ${theme.vibe !== 'fun' ? 'translate-y-[400px]' : 'translate-y-0'}`}
         src={yellowSweater} 
         alt="Luke Schlangen in a Yellow Sweater" 
         height={400} 
-        priority 
+        priority={theme.vibe === 'fun'}
       />
 
     </div>

--- a/src/app/components/toggles/color-toggle.tsx
+++ b/src/app/components/toggles/color-toggle.tsx
@@ -23,6 +23,7 @@ export default function ColorToggle({
           color: "light",
           ...deploymentConfiguration,
         })}
+        prefetch={false}
         className={color === "light" ? "" : "opacity-50 hover:opacity-100"}
       >
         ☀️
@@ -33,6 +34,7 @@ export default function ColorToggle({
           color: "dark",
           ...deploymentConfiguration,
         })}
+        prefetch={false}
         className={color === "dark" ? "" : "opacity-50 hover:opacity-100"}
       >
         🌙

--- a/src/app/components/toggles/page-toggle.tsx
+++ b/src/app/components/toggles/page-toggle.tsx
@@ -23,6 +23,7 @@ export default function PageToggle({
           page: "home",
           ...deploymentConfiguration,
         })}
+        prefetch={false}
         className={
           page === "home" ? "" : "underline opacity-50 hover:opacity-100"
         }
@@ -35,6 +36,7 @@ export default function PageToggle({
           page: "faq",
           ...deploymentConfiguration,
         })}
+        prefetch={false}
         className={page === "faq" ? "" : "opacity-50 hover:opacity-100"}
       >
         ❓
@@ -45,6 +47,7 @@ export default function PageToggle({
           page: "deploy",
           ...deploymentConfiguration,
         })}
+        prefetch={false}
         className={page === "deploy" ? "" : "opacity-50 hover:opacity-100"}
       >
         🚀

--- a/src/app/components/toggles/tense-toggle.tsx
+++ b/src/app/components/toggles/tense-toggle.tsx
@@ -19,6 +19,7 @@ export default function TenseToggle({
           tense: "first-person",
           ...deploymentConfiguration,
         })}
+        prefetch={false}
         className={tense === "first-person" ? "underline" : ""}
       >
         1st Person
@@ -30,6 +31,7 @@ export default function TenseToggle({
           tense: "third-person",
           ...deploymentConfiguration,
         })}
+        prefetch={false}
         className={tense === "third-person" ? "underline" : ""}
       >
         3rd Person

--- a/src/app/components/toggles/verbosity-toggle.tsx
+++ b/src/app/components/toggles/verbosity-toggle.tsx
@@ -19,6 +19,7 @@ export default function VerbosityToggle({
           ...deploymentConfiguration,
           verbosity: "short",
         })}
+        prefetch={false}
         className={verbosity === "short" ? "underline" : ""}
       >
         Short
@@ -30,6 +31,7 @@ export default function VerbosityToggle({
           ...deploymentConfiguration,
           verbosity: "medium",
         })}
+        prefetch={false}
         className={verbosity === "medium" ? "underline" : ""}
       >
         Medium
@@ -41,6 +43,7 @@ export default function VerbosityToggle({
           ...deploymentConfiguration,
           verbosity: "long",
         })}
+        prefetch={false}
         className={verbosity === "long" ? "underline" : ""}
       >
         Long

--- a/src/app/components/toggles/vibe-toggle.tsx
+++ b/src/app/components/toggles/vibe-toggle.tsx
@@ -23,6 +23,7 @@ export default function VibeToggle({
           vibe: "professional",
           ...deploymentConfiguration,
         })}
+        prefetch={false}
         className={
           vibe === "professional" ? "" : "opacity-50 hover:opacity-100"
         }
@@ -35,6 +36,7 @@ export default function VibeToggle({
           vibe: "standard",
           ...deploymentConfiguration,
         })}
+        prefetch={false}
         className={vibe === "standard" ? "" : "opacity-50 hover:opacity-100"}
       >
         😃
@@ -45,6 +47,7 @@ export default function VibeToggle({
           vibe: "fun",
           ...deploymentConfiguration,
         })}
+        prefetch={false}
         className={vibe === "fun" ? "" : "opacity-50 hover:opacity-100"}
       >
         🎉


### PR DESCRIPTION
This PR addresses two key performance issues from the Lighthouse report:
1. **LCP Optimization**: In `profile-image.tsx`, we now only set `priority={true}` for the headshot that is actually visible based on the current theme vibe. Previously, all three images were being prioritized, leading to network contention. I also fixed a Tailwind typo where `translate-y-100` (invalid) was used instead of `translate-y-[400px]`.
2. **Unused JS Reduction**: Next.js defaults to prefetching all `<Link>` components in the viewport. Because we have many toggles for different site states, the heavy `@tsparticles/confetti` library (used for the 'fun' vibe) was being loaded on every page load. By setting `prefetch={false}` on these toggles, we ensure this JavaScript is only fetched when a user actively chooses to change the vibe.

Verification was performed using Playwright to ensure images toggle correctly and no visual regressions were introduced.

---
*PR created automatically by Jules for task [16147526480231108024](https://jules.google.com/task/16147526480231108024) started by @LukeSchlangen*