### PR TITLE
Enable WebMCP site-wide

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@mcp-b/global": "^2.3.2",
     "@tsparticles/confetti": "^3.9.1",
     "@types/node": "24.10.1",
     "@types/react": "19.2.7",
@@ -18,7 +19,9 @@
     "react-dom": "^19.2.0",
     "react-social-icons": "^6.25.0",
     "sharp": "^0.34.5",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "zod": "^4.4.3",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@mcp-b/global':
+        specifier: ^2.3.2
+        version: 2.3.2(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@tsparticles/confetti':
         specifier: ^3.9.1
         version: 3.9.1
@@ -38,6 +41,12 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@4.4.3)
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.3
@@ -91,6 +100,9 @@ packages:
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
@@ -324,6 +336,32 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mcp-b/global@2.3.2':
+    resolution: {integrity: sha512-44+Rxn2cuwJKUwVBi/xwpQ/+yEuKrmrrOJH/vysyr7JbE74Pr2Pfqb8YZCWwpk6wB4jwBHIfrFWigNfeMMaYAQ==}
+    engines: {node: '>=18'}
+
+  '@mcp-b/transports@2.3.2':
+    resolution: {integrity: sha512-aRKaF1TjwSBXEXYUpWfz3JKOiagYMHH4D7gpesaU1aGAs69cjTVX4lDwFZ9qIO+4a/1CijLcBnOsKmsPzFWQjA==}
+
+  '@mcp-b/webmcp-polyfill@2.3.2':
+    resolution: {integrity: sha512-kvGmGypnsASUUGLI/NJ2E1eNLhtRkOq+dxaXxv01EKli9C78hb7x1KpIfknSCxpfIufJGE8wzjjIf279pQT/gQ==}
+    engines: {node: '>=18'}
+
+  '@mcp-b/webmcp-ts-sdk@2.3.2':
+    resolution: {integrity: sha512-mRZMXSM7bNkNsnGws884DpcatwZCYoAFIaV39Bb/YsBjLKhGYA8/9z4GmftIPnKFZm+BljYi9h+AUMgEc/Cz4Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25 || ^4.0
+      zod-to-json-schema: ^3.25.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+      zod-to-json-schema:
+        optional: true
+
+  '@mcp-b/webmcp-types@2.3.2':
+    resolution: {integrity: sha512-167nu2e5qIh8BcKvFp4dUzaeyO1+S+eMWGUaohjkwnqgc2Gq49Fv+i/Lei19019s1iCfQJ3yjtrzDK0nApivKg==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -410,6 +448,9 @@ packages:
 
   '@rushstack/eslint-patch@1.15.0':
     resolution: {integrity: sha512-ojSshQPKwVvSMR8yT2L/QtUkV5SXi/IfDiJ4/8d6UbTPjiHVmxZzUAzGD8Tzks1b9+qQkZa0isUOvYObedITaw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -2079,11 +2120,24 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
   '@babel/runtime@7.28.4': {}
+
+  '@cfworker/json-schema@4.1.1': {}
 
   '@emnapi/core@1.7.1':
     dependencies:
@@ -2273,6 +2327,47 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mcp-b/global@2.3.2(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@mcp-b/transports': 2.3.2(zod-to-json-schema@3.25.2(zod@4.4.3))
+      '@mcp-b/webmcp-polyfill': 2.3.2
+      '@mcp-b/webmcp-ts-sdk': 2.3.2(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
+      '@mcp-b/webmcp-types': 2.3.2
+    transitivePeerDependencies:
+      - zod
+      - zod-to-json-schema
+
+  '@mcp-b/transports@2.3.2(zod-to-json-schema@3.25.2(zod@4.4.3))':
+    dependencies:
+      '@mcp-b/webmcp-ts-sdk': 2.3.2(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - zod-to-json-schema
+
+  '@mcp-b/webmcp-polyfill@2.3.2':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@mcp-b/webmcp-types': 2.3.2
+      '@standard-schema/spec': 1.1.0
+
+  '@mcp-b/webmcp-ts-sdk@2.3.2(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@3.25.76)':
+    dependencies:
+      '@mcp-b/webmcp-polyfill': 2.3.2
+      '@mcp-b/webmcp-types': 2.3.2
+    optionalDependencies:
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+
+  '@mcp-b/webmcp-ts-sdk@2.3.2(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@mcp-b/webmcp-polyfill': 2.3.2
+      '@mcp-b/webmcp-types': 2.3.2
+    optionalDependencies:
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+
+  '@mcp-b/webmcp-types@2.3.2': {}
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.7.1
@@ -2329,6 +2424,8 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.15.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -4226,3 +4323,11 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@3.25.76: {}
+
+  zod@4.4.3: {}

--- a/src/app/components/webmcp-initializer.tsx
+++ b/src/app/components/webmcp-initializer.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useEffect } from "react";
+import "@mcp-b/global";
+import { useRouter } from "next/navigation";
+import pathBuilder from "../utils/path-builder";
+import {
+  PAGE_OPTIONS,
+  VIBE_OPTIONS,
+  COLOR_OPTIONS,
+  TENSE_OPTIONS,
+  VERBOSITY_OPTIONS,
+  FRAMEWORK_OPTIONS,
+  TARGET_OPTIONS,
+  SOURCE_OPTIONS,
+  FRAMEWORK_DETAILS,
+  Theme,
+  DeploymentConfiguration,
+  TenseOption,
+  VerbosityOption,
+  PageOption,
+  VibeOption,
+  ColorOption,
+  FrameworkOption,
+  TargetOption,
+  SourceOption,
+} from "../types";
+
+export default function WebMcpInitializer() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const mc = (navigator as any).modelContext;
+    if (!mc) return;
+
+    mc.registerTool({
+      name: "get_bio",
+      description: "Returns Luke Schlangen's bio in a specific tense and verbosity.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          tense: {
+            type: "string",
+            enum: TENSE_OPTIONS,
+            description: "The grammatical tense (first-person or third-person)",
+          },
+          verbosity: {
+            type: "string",
+            enum: VERBOSITY_OPTIONS,
+            description: "The length of the bio (short, medium, or long)",
+          },
+        },
+        required: ["tense", "verbosity"],
+      },
+      execute: async (args: { tense: TenseOption; verbosity: VerbosityOption }) => {
+        const { tense, verbosity } = args;
+        const isFirstPerson = tense === "first-person";
+
+        const devAdvocate = "developer advocate at Google";
+        const coFounder = "co-founder of Code Championship: a competitive computer coding program for 3rd to 9th grade students";
+        const learningBelief = "learning follows excitement";
+        const techStack = "Firebase, Google Cloud Run, and Google Kubernetes Engine";
+
+        if (verbosity === "short") {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `${isFirstPerson ? "I am a " : "Luke is a "}${devAdvocate}.\n${isFirstPerson ? "I am a " : "He is a "}${coFounder}.\n${isFirstPerson ? "I believe " : "He believes "}${learningBelief}.`,
+              },
+            ],
+          };
+        }
+
+        if (verbosity === "medium") {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `${isFirstPerson ? "I am a " : "Luke is a "}${devAdvocate} who believes ${learningBelief}. ${isFirstPerson ? "I like " : "He likes "}giving approachable talks for beginners, because everyone is a beginner at something.\n\n${isFirstPerson ? "I " : "He "}previously taught at a coding bootcamp. After that, ${isFirstPerson ? "I " : "He "}led an onboarding program for new software engineers at a Fortune 500 company. Now at Google, ${isFirstPerson ? "I like to " : "he likes to "}help developers deploy their applications to places like ${techStack}.\n\nOutside of ${isFirstPerson ? "my " : "his "}work at Google, ${isFirstPerson ? "I am a " : "he is a "}${coFounder}.`,
+              },
+            ],
+          };
+        }
+
+        // Long bio
+        return {
+          content: [
+            {
+              type: "text",
+              text: `${isFirstPerson ? "I am a " : "Luke is a "}${devAdvocate} who believes ${learningBelief}. ${isFirstPerson ? "I like " : "He likes "}giving approachable talks for beginners, because everyone is a beginner at something.\n\n${isFirstPerson ? "I am " : "He is "}working on making it easier to deploy your application to the world.\n\n${isFirstPerson ? "I " : "He "}previously taught at a coding bootcamp. After that, ${isFirstPerson ? "I " : "He "}led an onboarding program for new software engineers at a Fortune 500 company. Now at Google, ${isFirstPerson ? "I like to " : "he likes to "}help developers deploy their applications to places like ${techStack}.\n\nOutside of ${isFirstPerson ? "my " : "his "}work at Google, ${isFirstPerson ? "I am a " : "he is a "}${coFounder}.\n\nIf you want to know more about what ${isFirstPerson ? "I think" : "he thinks"}, you could check out the FAQ page.`,
+            },
+          ],
+        };
+      },
+    });
+
+    mc.registerTool({
+      name: "list_faq",
+      description: "Returns a list of frequently asked questions and their answers.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+      },
+      execute: async () => {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify([
+                {
+                  category: "Learning to Code",
+                  questions: [
+                    {
+                      question: "Where should I start?",
+                      answer: "It depends on what you want to do. For a career change, consider reputable schools. Harvard's CS50 is a great free guided course. Otherwise, start with a project that excites you!",
+                    },
+                    {
+                      question: "What is a good project?",
+                      answer: "Anything you are passionate about. Automating redundant tasks, creating a video game in Scratch, or building a website are all great starts.",
+                    },
+                  ],
+                },
+                {
+                  category: "Software Career",
+                  questions: [
+                    {
+                      question: "How did you get your first job in tech?",
+                      answer: "Used connections, took a pay cut, and got lucky. The industry has changed since then, but these factors still play a role.",
+                    },
+                    {
+                      question: "How did you get a job at Google?",
+                      answer: "Applied four times over ten years. The successful attempt was after five years of teaching software. Persistence and relevant experience were key.",
+                    },
+                  ],
+                },
+                {
+                  category: "Tech Talent Shortage",
+                  questions: [
+                    {
+                      question: "Is the tech talent shortage real?",
+                      answer: "It depends on perspective. There's a lot of entry-level talent, but companies often struggle because they are unwilling to pay market rates for senior talent or aren't good at onboarding juniors.",
+                    },
+                    {
+                      question: "Should we be teaching computer science to students?",
+                      answer: "Yes, everyone should know a bit about code as it will be an important part of their lives.",
+                    },
+                    {
+                      question: "How can I find entry-level talent?",
+                      answer: "There's plenty available. Prime Digital Academy is a great place to start looking.",
+                    },
+                    {
+                      question: "How can I find senior talent?",
+                      answer: "Post the salary in the job description. If you can't afford it, hire juniors and invest in their onboarding.",
+                    },
+                    {
+                      question: "How can we onboard new talent?",
+                      answer: "Implement daily 30-minute 'unstuck sessions' with senior engineers to show it's okay to ask for help.",
+                    },
+                  ],
+                },
+              ]),
+            },
+          ],
+        };
+      },
+    });
+
+    mc.registerTool({
+      name: "get_deployment_steps",
+      description: "Returns steps to create and deploy an application based on framework and target.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          framework: {
+            type: "string",
+            enum: FRAMEWORK_OPTIONS,
+            description: "The web framework to use",
+          },
+          target: {
+            type: "string",
+            enum: TARGET_OPTIONS,
+            description: "The deployment target",
+          },
+          appName: {
+            type: "string",
+            description: "The name of the application",
+          },
+        },
+        required: ["framework", "target", "appName"],
+      },
+      execute: async (args: { framework: FrameworkOption; target: TargetOption; appName: string }) => {
+        const { framework, target, appName } = args;
+        const frameworkDetails = FRAMEWORK_DETAILS[framework];
+        const source = "local"; // Defaulting to local source
+
+        const prerequisites = [
+          ...frameworkDetails.prerequisites({ appName }),
+          ...frameworkDetails.targets[target].sources[source].prerequisites({ appName }),
+        ];
+        const createApplication = [
+          ...frameworkDetails.createApplication({ appName }),
+          ...frameworkDetails.targets[target].sources[source].createApplication({ appName }),
+        ];
+        const runLocally = [
+          ...frameworkDetails.runLocally({ appName }),
+          ...frameworkDetails.targets[target].sources[source].runLocally({ appName }),
+        ];
+        const deployApplication = [
+          ...frameworkDetails.deployApplication({ appName }),
+          ...frameworkDetails.targets[target].sources[source].deployApplication({ appName }),
+        ];
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                prerequisites,
+                createApplication,
+                runLocally,
+                deployApplication,
+              }),
+            },
+          ],
+        };
+      },
+    });
+
+    mc.registerTool({
+      name: "get_theme_options",
+      description: "Returns the available options for customizing the website's theme and content.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+      },
+      execute: async () => {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                pages: PAGE_OPTIONS,
+                vibes: VIBE_OPTIONS,
+                colors: COLOR_OPTIONS,
+                tenses: TENSE_OPTIONS,
+                verbosities: VERBOSITY_OPTIONS,
+                frameworks: FRAMEWORK_OPTIONS,
+                targets: TARGET_OPTIONS,
+                sources: SOURCE_OPTIONS,
+              }),
+            },
+          ],
+        };
+      },
+    });
+
+    mc.registerTool({
+      name: "navigate_to",
+      description: "Navigates the website to a specific page or theme configuration.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          page: { type: "string", enum: PAGE_OPTIONS },
+          vibe: { type: "string", enum: VIBE_OPTIONS },
+          color: { type: "string", enum: COLOR_OPTIONS },
+          tense: { type: "string", enum: TENSE_OPTIONS },
+          verbosity: { type: "string", enum: VERBOSITY_OPTIONS },
+          framework: { type: "string", enum: FRAMEWORK_OPTIONS },
+          target: { type: "string", enum: TARGET_OPTIONS },
+          source: { type: "string", enum: SOURCE_OPTIONS },
+        },
+      },
+      execute: async (args: Theme & DeploymentConfiguration) => {
+        // Build the path with current defaults for missing values
+        // Note: In a real app, you might want to merge with the current URL state,
+        // but pathBuilder takes everything it needs.
+        const path = pathBuilder({
+          page: args.page || "home",
+          vibe: args.vibe || "standard",
+          color: args.color || "light",
+          tense: args.tense || "first-person",
+          verbosity: args.verbosity || "medium",
+          framework: args.framework || "angular-ssr",
+          target: args.target || "cloud-run",
+          source: args.source || "local",
+        });
+
+        router.push(path);
+        return {
+          content: [{ type: "text", text: `Navigating to ${path}` }],
+        };
+      },
+    });
+  }, [router]);
+
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import WebMcpInitializer from "./components/webmcp-initializer";
 
 export const metadata: Metadata = {
   title: "Luke Schlangen | Software Engineer",
@@ -14,7 +15,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <WebMcpInitializer />
+        {children}
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
Enabled WebMCP throughout the site using `@mcp-b/global` polyfill and a new `WebMcpInitializer` component. Exposes several tools for AI agents to interact with the site's content and navigation.

---
*PR created automatically by Jules for task [7652489707789142136](https://jules.google.com/task/7652489707789142136) started by @LukeSchlangen*