### PR TITLE
Hide Scrollbar on Explanation Panel

### DIFF
--- a/src/app/components/pages/quiz-page.tsx
+++ b/src/app/components/pages/quiz-page.tsx
@@ -775,8 +775,9 @@ function QuizViewport({
                 overflow: "hidden",
                 transition: `all ${transitionTime}s cubic-bezier(0.4, 0, 0.2, 1)`,
               }}
+              className="no-scrollbar"
             >
-              <div className="text-center text-white px-[0.8em] py-[0.6em] bg-black/55 border-[0.05em] border-white/10 rounded-none flex flex-col justify-center h-full shadow-inner overflow-y-auto max-h-[10em]">
+              <div className="text-center text-white px-[0.8em] py-[0.6em] bg-black/55 border-[0.05em] border-white/10 rounded-none flex flex-col justify-center h-full shadow-inner overflow-y-auto max-h-[10em] no-scrollbar">
                 <span className="text-[0.6em] font-bold text-white/40 tracking-widest block mb-[0.2em] uppercase">
                   Explanation
                 </span>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,3 +5,14 @@
     list-style-type: ">";
     padding-inline-start: 1ch;
 }
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+.no-scrollbar::-webkit-scrollbar {
+    display: none;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+.no-scrollbar {
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+}


### PR DESCRIPTION
We added a custom cross-browser `.no-scrollbar` utility class in `src/app/globals.css` that hides scrollbars on WebKit (Chrome, Safari, Opera), Firefox, Edge, and IE browsers. We then applied this class to both the outer animated wrapper div and the inner scrollable container div for the explanation card in the presentation player of `src/app/components/pages/quiz-page.tsx`. This ensures that scrollbars are never visible even as the container scales dynamically up to full height during the Phase 6 transition or when the text content overflows.

---
*PR created automatically by Jules for task [11695690475955583012](https://jules.google.com/task/11695690475955583012) started by @LukeSchlangen*