### PR TITLE
Make Highlighted Quiz Borders More Prominent

### DIFF
--- a/dev_output.log
+++ b/dev_output.log
@@ -4,9 +4,10 @@ $ next dev
 - Network:       http://192.168.0.2:3000
 
 ✓ Starting...
-✓ Ready in 716ms
+✓ Ready in 757ms
 Browserslist: browsers data (caniuse-lite) is 8 months old. Please run:
   npx update-browserslist-db@latest
   Why you should do it regularly: https://github.com/browserslist/update-db#readme
 ○ Compiling /quiz/[[...slug]] ...
- GET /quiz 200 in 4.2s (compile: 3.9s, render: 357ms)
+ HEAD /quiz 200 in 4.9s (compile: 4.6s, render: 296ms)
+ GET /quiz 200 in 158ms (compile: 28ms, render: 130ms)

--- a/src/app/components/pages/quiz-page.tsx
+++ b/src/app/components/pages/quiz-page.tsx
@@ -1576,7 +1576,7 @@ function QuizViewport({
 
               let borderClass = "border-white/10";
               if (isHighlighted) {
-                borderClass = "border-white/80";
+                borderClass = "border-white/95";
               } else if (phase === 5) {
                 borderClass = "border-white/25";
               } else if (phase !== "edit" && phase >= 1) {
@@ -1595,7 +1595,7 @@ function QuizViewport({
                     zIndex,
                     transition: `all ${transitionTime}s cubic-bezier(0.4, 0, 0.2, 1)`,
                   }}
-                  className={`overflow-hidden rounded-[1em] relative border-[0.05em] shrink-0 ${isCorrectHighlighted ? "border-transparent shadow-[0_0_1.5em_rgba(255,255,255,0.15)]" : borderClass}`}
+                  className={`overflow-hidden rounded-[1em] relative ${isHighlighted ? "border-[0.12em]" : "border-[0.05em]"} shrink-0 ${isCorrectHighlighted ? "border-transparent shadow-[0_0_1.5em_rgba(255,255,255,0.15)]" : borderClass}`}
                 >
                   {isCorrectHighlighted && (
                     <svg className="absolute inset-0 w-full h-full pointer-events-none z-20">


### PR DESCRIPTION
This change updates the highlight styling of the quiz page answer cards during option iteration.
When an option is highlighted (isHighlighted), its border opacity is increased from border-white/80 to border-white/95, and its border width is increased from border-[0.05em] to border-[0.12em] to make the selection much more prominent and visually distinct.

---
*PR created automatically by Jules for task [15186513058911313749](https://jules.google.com/task/15186513058911313749) started by @LukeSchlangen*