### PR TITLE
Fix quiz answers layout shift on option iteration

### DIFF
--- a/dev_output.log
+++ b/dev_output.log
@@ -4,10 +4,10 @@ $ next dev
 - Network:       http://192.168.0.2:3000
 
 ✓ Starting...
-✓ Ready in 757ms
+✓ Ready in 737ms
 Browserslist: browsers data (caniuse-lite) is 8 months old. Please run:
   npx update-browserslist-db@latest
   Why you should do it regularly: https://github.com/browserslist/update-db#readme
 ○ Compiling /quiz/[[...slug]] ...
- HEAD /quiz 200 in 4.9s (compile: 4.6s, render: 296ms)
- GET /quiz 200 in 158ms (compile: 28ms, render: 130ms)
+ GET /quiz 200 in 4.2s (compile: 3.9s, render: 350ms)
+ GET /quiz 200 in 137ms (compile: 23ms, render: 114ms)

--- a/src/app/components/pages/quiz-page.tsx
+++ b/src/app/components/pages/quiz-page.tsx
@@ -1595,7 +1595,7 @@ function QuizViewport({
                     zIndex,
                     transition: `all ${transitionTime}s cubic-bezier(0.4, 0, 0.2, 1)`,
                   }}
-                  className={`overflow-hidden rounded-[1em] relative ${isHighlighted ? "border-[0.12em]" : "border-[0.05em]"} shrink-0 ${isCorrectHighlighted ? "border-transparent shadow-[0_0_1.5em_rgba(255,255,255,0.15)]" : borderClass}`}
+                  className={`overflow-hidden rounded-[1em] relative border-[0.12em] shrink-0 ${isCorrectHighlighted ? "border-transparent shadow-[0_0_1.5em_rgba(255,255,255,0.15)]" : borderClass}`}
                 >
                   {isCorrectHighlighted && (
                     <svg className="absolute inset-0 w-full h-full pointer-events-none z-20">


### PR DESCRIPTION
Consistently apply border-[0.12em] class to quiz answer option cards to ensure there is no text reflow or layout shift when elements are highlighted during presenter playback loop.

---
*PR created automatically by Jules for task [4913083916218602220](https://jules.google.com/task/4913083916218602220) started by @LukeSchlangen*