### PR TITLE
Fix top border clipping on first quiz answer

### DIFF
--- a/dev_output.log
+++ b/dev_output.log
@@ -4,10 +4,10 @@ $ next dev
 - Network:       http://192.168.0.2:3000
 
 ✓ Starting...
-✓ Ready in 737ms
+✓ Ready in 726ms
 Browserslist: browsers data (caniuse-lite) is 8 months old. Please run:
   npx update-browserslist-db@latest
   Why you should do it regularly: https://github.com/browserslist/update-db#readme
 ○ Compiling /quiz/[[...slug]] ...
- GET /quiz 200 in 4.2s (compile: 3.9s, render: 350ms)
- GET /quiz 200 in 137ms (compile: 23ms, render: 114ms)
+ GET /quiz 200 in 4.3s (compile: 3.9s, render: 360ms)
+ GET /quiz 200 in 127ms (compile: 23ms, render: 105ms)

--- a/src/app/components/pages/quiz-page.tsx
+++ b/src/app/components/pages/quiz-page.tsx
@@ -1539,7 +1539,7 @@ function QuizViewport({
         }}
       >
         <div className="flex-1 flex flex-col justify-center space-y-[0.8em] py-[0.5em] h-full overflow-hidden w-full max-w-[88%] mx-auto">
-          <div className="flex-1 flex flex-col justify-center overflow-hidden">
+          <div className="flex-1 flex flex-col justify-center overflow-visible">
             {questionData.answers.map((ans, i) => {
               const isHighlighted = phase !== "edit" && phase >= 1 && phase <= 4 && (phase - 1) === i;
               const isCorrect = questionData.correctIndex === i;


### PR DESCRIPTION
Fixed a layout issue in the quiz presentation player where the top border/glow of the first answer option was clipped by its parent's overflow container. Replaced `overflow-hidden` with `overflow-visible` on the immediate flex container holding the answer items to let elements render completely inside the padded vertical area. Checked using a production build, ESLint, and a Playwright-driven screenshot test to confirm correctness.

---
*PR created automatically by Jules for task [1944381634915997560](https://jules.google.com/task/1944381634915997560) started by @LukeSchlangen*