### PR TITLE
Animate Quiz Explanation to Fly In from the Bottom

### DIFF
--- a/dev_output.log
+++ b/dev_output.log
@@ -1,13 +1,9 @@
 $ next dev
-▲ Next.js 16.1.6 (Turbopack)
+▲ Next.js 16.2.10 (Turbopack)
 - Local:         http://localhost:3000
 - Network:       http://192.168.0.2:3000
+✓ Ready in 539ms
 
-✓ Starting...
-✓ Ready in 726ms
-Browserslist: browsers data (caniuse-lite) is 8 months old. Please run:
-  npx update-browserslist-db@latest
-  Why you should do it regularly: https://github.com/browserslist/update-db#readme
 ○ Compiling /quiz/[[...slug]] ...
- GET /quiz 200 in 4.3s (compile: 3.9s, render: 360ms)
- GET /quiz 200 in 127ms (compile: 23ms, render: 105ms)
+ HEAD /quiz 200 in 4.3s (next.js: 3.9s, application-code: 346ms)
+ GET /quiz 200 in 235ms (next.js: 54ms, application-code: 180ms)

--- a/src/app/components/pages/quiz-page.tsx
+++ b/src/app/components/pages/quiz-page.tsx
@@ -1666,7 +1666,8 @@ function QuizViewport({
                 opacity: phase === 6 ? 1 : 0,
                 marginTop: phase === 6 ? "0.6em" : "0px",
                 overflow: "hidden",
-                transition: `all ${transitionTime}s cubic-bezier(0.4, 0, 0.2, 1)`,
+                transform: phase === 6 ? "translateY(0)" : "translateY(100%)",
+                transition: `transform ${transitionTime}s cubic-bezier(0.4, 0, 0.2, 1), opacity ${transitionTime}s cubic-bezier(0.4, 0, 0.2, 1)`,
                 fontSize: explanationFontSize ? `${explanationFontSize / 0.85}px` : undefined,
               }}
             >


### PR DESCRIPTION
Restricted the transition of the quiz page explanation container to only transform and opacity, making it assume its full size instantly and then fly in smoothly from the bottom.

---
*PR created automatically by Jules for task [13374528089631686386](https://jules.google.com/task/13374528089631686386) started by @LukeSchlangen*